### PR TITLE
fixed issue for reading the tags list for controllers below v18. The …

### DIFF
--- a/pycomm3/const.py
+++ b/pycomm3/const.py
@@ -34,6 +34,7 @@ MULTISERVICE_WRITE_OVERHEAD = 3
 
 MIN_VER_INSTANCE_IDS = 21  # using Symbol Instance Addressing not supported below version 21
 MIN_VER_LARGE_CONNECTIONS = 20  # >500 byte connections not supported below logix v20
+MIN_VER_EXTERNAL_ACCESS = 18  # ExternalAccess attributed added in v18
 
 EXTENDED_SYMBOL = b'\x91'
 BOOL_ONE = 0xff

--- a/setup.py
+++ b/setup.py
@@ -38,3 +38,8 @@ setup(
     ],
 
 )
+
+# Build and Publish Commands:
+#
+# python setup.py sdist bdist_wheel
+# twine upload --skip-existing dist/*


### PR DESCRIPTION
…'ExternalAccess' attribute didn't exist before then and would lead to reading the tag list to fail.  As long as the plc info is read, it will automatically skip that attribute for firmware below v18.  setting plc.info['version_major'] to a value beflow 18 will have the same effect