### PR TITLE
fix for the service or command errors from being hidden when a single…

### DIFF
--- a/pycomm3/packets/responses.py
+++ b/pycomm3/packets/responses.py
@@ -136,7 +136,10 @@ class ReadTagServiceResponsePacket(SendUnitDataResponsePacket):
     def _parse_reply(self):
         try:
             super()._parse_reply()
-            self.value, self.data_type = parse_read_reply(self.data, self.tag_info, self.elements)
+            if self.is_valid():
+                self.value, self.data_type = parse_read_reply(self.data, self.tag_info, self.elements)
+            else:
+                self.value, self.data_type = None, None
         except Exception as err:
             self.__log.exception('Failed parsing reply data')
             self.value = None
@@ -170,8 +173,11 @@ class ReadTagFragmentedServiceResponsePacket(SendUnitDataResponsePacket):
 
     def parse_bytes(self):
         try:
-            self.value, self.data_type = parse_read_reply(self._data_type + self.bytes_,
+            if self.is_valid():
+                self.value, self.data_type = parse_read_reply(self._data_type + self.bytes_,
                                                           self.tag_info, self.elements)
+            else:
+                self.value, self.data_type = None, None
         except Exception as err:
             self.__log.exception('Failed parsing reply data')
             self.value = None


### PR DESCRIPTION
… tag or fragmented tag read fails.  they were being hidden b/c an exception would be thrown trying to parse a failed read, so the error would not indicate why the read failed just that it failed to parse the value