### PR TITLE
fix to remove empty multi-requests packets 

### DIFF
--- a/pycomm3/__init__.py
+++ b/pycomm3/__init__.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 
-__version_info__ = (0, 6, 0)
+__version_info__ = (0, 6, 1)
 __version__ = '.'.join(f'{x}' for x in __version_info__)
 
 from typing import NamedTuple, Any, Optional

--- a/pycomm3/clx.py
+++ b/pycomm3/clx.py
@@ -1056,7 +1056,7 @@ class LogixDriver:
                 self.__log.error(f'Skipping making request for {tag}, error: {tag_data.get("error")}')
                 continue
 
-        return requests
+        return (r for r in requests if (r.type_ == 'multi' and r.tags) or r.type_ == 'read')
 
     def _read_build_single_request(self, parsed_tag):
         """
@@ -1175,7 +1175,7 @@ class LogixDriver:
                     self.__log.exception(f'Failed to build request for {tag} - skipping')
                     continue
 
-        return requests
+        return (r for r in requests if (r.type_ == 'multi' and r.tags) or r.type_ == 'write')
 
     def _write_build_single_request(self, parsed_tag, bit_writes):
         if parsed_tag.get('error') is None:


### PR DESCRIPTION
if all tags in a read/write require fragmented packets there could be an empty multi-request packet left over which will throw an error when trying to send all the requests