### PR TITLE
Develop

### DIFF
--- a/pycomm3/__init__.py
+++ b/pycomm3/__init__.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 
-__version_info__ = (0, 6, 4)
+__version_info__ = (0, 6, 5)
 __version__ = '.'.join(f'{x}' for x in __version_info__)
 
 from typing import NamedTuple, Any, Optional


### PR DESCRIPTION
added option to embed unconnected_send service in a generic request
fixed issue where get_plc_info was requsting the wrong module's identity object due to the generic request changes (mainly missing the unconnected send portion and the CIP route)