### PR TITLE
type information for mypy users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     long_description=read('README.rst'),
     license="MIT",
     packages=['pycomm3', 'pycomm3.packets'],
+    package_data={'pycomm3': ['py.typed']},
     python_requires='>=3.6.1',
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Per the mypy documentation:
https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages

the alternative needed in this case is to add a `py.typed`
empty marker file so that mypy knows such directory should be
included in typechecking.

Also added package_data to setup.py

After this change, mypy know no longer issues this warning:
```
 error: Skipping analyzing 'pycomm3': found module but no type hints or library stubs
```

