### PR TITLE
SLC list files

### DIFF
--- a/pycomm3/bytes_.py
+++ b/pycomm3/bytes_.py
@@ -128,6 +128,7 @@ class Pack(EnumMap):
     pccc_a: Callable[[int], bytes] = _encode_pccc_ascii
     pccc_r: Callable[[int], bytes] = dint
     pccc_st: Callable[[str], bytes] = _encode_pccc_string
+    pccc_l: Callable[[bytes], int] = dint
 
 
 class Unpack(EnumMap):
@@ -161,6 +162,7 @@ class Unpack(EnumMap):
     pccc_a: Callable[[bytes], int] = _decode_pccc_ascii
     pccc_r: Callable[[bytes], int] = dint
     pccc_st: Callable[[bytes], str] = _decode_pccc_string
+    pccc_l: Callable[[bytes], int] = dint
 
 
 def print_bytes_line(msg):

--- a/pycomm3/const.py
+++ b/pycomm3/const.py
@@ -35,6 +35,7 @@ READ_RESPONSE_OVERHEAD = 10
 MIN_VER_INSTANCE_IDS = 21  # using Symbol Instance Addressing not supported below version 21
 MIN_VER_LARGE_CONNECTIONS = 20  # >500 byte connections not supported below logix v20
 MIN_VER_EXTERNAL_ACCESS = 18  # ExternalAccess attributed added in v18
+
 MICRO800_PREFIX = '2080'  # catalog number prefix for Micro800 PLCs
 
 EXTENDED_SYMBOL = b'\x91'
@@ -60,6 +61,7 @@ SLC_FNC_READ = b'\xa2'  # protected typed logical read w/ 3 address fields
 SLC_FNC_WRITE = b'\xaa'  # protected typed logical write w/ 3 address fields
 SLC_REPLY_START = 61
 PCCC_PATH = b'\x67\x24\x01'
+
 
 ELEMENT_TYPE = {
     "8-bit": b'\x28',
@@ -444,7 +446,7 @@ EXTEND_CODES = {
 }
 
 
-PCCC_DATA_TYPE = {
+_PCCC_DATA_TYPE = {
     'N': b'\x89',
     'B': b'\x85',
     'T': b'\x86',
@@ -454,14 +456,25 @@ PCCC_DATA_TYPE = {
     'ST': b'\x8d',
     'A': b'\x8e',
     'R': b'\x88',
-    'O': b'\x8b',
-    'I': b'\x8c'
+    'O': b'\x8b',  # or b'\x82'?
+    'I': b'\x8c',  # or b'\x83'?
+    'L': b'\x91',
+    'MG': b'\x92',
+    'PD': b'\x93',
+    'PLS': b'\x94',
+}
+
+PCCC_DATA_TYPE = {
+    **_PCCC_DATA_TYPE,
+    **{v: k for k, v in _PCCC_DATA_TYPE.items()},
+    b'\x82': 'O',
+    b'\x83': 'I',
 }
 
 
 PCCC_DATA_SIZE = {
     'N': 2,
-    # 'L': 4,
+    'L': 4,
     'B': 2,
     'T': 6,
     'C': 6,
@@ -471,7 +484,10 @@ PCCC_DATA_SIZE = {
     'A': 2,
     'R': 6,
     'O': 2,
-    'I': 2
+    'I': 2,
+    'MG': 50,
+    'PD': 46,
+    'PLS': 12,
 }
 
 

--- a/pycomm3/const.py
+++ b/pycomm3/const.py
@@ -456,8 +456,8 @@ _PCCC_DATA_TYPE = {
     'ST': b'\x8d',
     'A': b'\x8e',
     'R': b'\x88',
-    'O': b'\x8b',  # or b'\x82'?
-    'I': b'\x8c',  # or b'\x83'?
+    'O': b'\x82',  # or b'\x8b'?
+    'I': b'\x83',  # or b'\x8c'?
     'L': b'\x91',
     'MG': b'\x92',
     'PD': b'\x93',
@@ -467,8 +467,6 @@ _PCCC_DATA_TYPE = {
 PCCC_DATA_TYPE = {
     **_PCCC_DATA_TYPE,
     **{v: k for k, v in _PCCC_DATA_TYPE.items()},
-    b'\x82': 'O',
-    b'\x83': 'I',
 }
 
 

--- a/pycomm3/slc.py
+++ b/pycomm3/slc.py
@@ -314,13 +314,14 @@ def _parse_file0(plc_type, data):
 
 
 def _get_file_and_element_for_plc_type(plc_type):
-    if plc_type in {'5/02', }:  # TODO: add MLX1000
+    prefix = plc_type[:4]
+    if prefix in {'5/02', '1761'}:  # SLC 5/02 MLX1000
         file_type = b'\x00'
         element = b'\x23'
-    elif plc_type in {}:  # TODO: add MLX1100/1200/1500
+    elif prefix in {'1763', '1762', '1764'}:  # MLX1100/1200/1500
         file_type = b'\x02'
         element = b'\x2F'
-    else:
+    else:  # other SLCs or MLX1400
         file_type = b'\x01'
         element = b'\x23'
 

--- a/pycomm3/slc.py
+++ b/pycomm3/slc.py
@@ -213,7 +213,7 @@ class SLCDriver(CIPDriver):
 
             if sys0_info['size'] is not None:
                 data = self._read_whole_file_directory(sys0_info)
-                return _parse_file0(plc_type, data)
+                return _parse_file0(sys0_info, data)
             else:
                 raise DataError('Failed to read file directory size')
         else:
@@ -319,66 +319,25 @@ def _parse_file0(sys0_info, data):
     return data_files
 
 
-def _get_file_and_element_for_plc_type(plc_type):
-    prefix = plc_type[:4]
-    if prefix in {'5/02', '1761'}:  # SLC 5/02 MLX1000
-        file_type = b'\x00'
-        element = b'\x23'
-    elif prefix in {'1763', '1762', '1764'}:  # MLX1100/1200/1500
-        file_type = b'\x02'
-        element = b'\x2F'
-    elif prefix in {'1763'}:  # MLX 1400
-        file_type = b'\x03'
-        element = b'\x2b'
-    else:  # other SLCs or
-        file_type = b'\x01'
-        element = b'\x23'
-
-    return file_type, element
-
-
-def _get_file_position_row_size_for_plc_type(plc_type):
-    prefix = plc_type[:4]
-    if prefix in {'5/02', '1761'}:  # SLC 5/02 MLX1000
-        file_pos = 93
-        row_size = 8
-    elif prefix in {'1763', '1762', '1764'}:  # MLX1100/1200/1500
-        file_pos = 103
-        row_size = 10
-    else:  # other SLCs or MLX1400
-        file_pos = 79
-        row_size = 10
-
-    return file_pos, row_size
-
-
 def _get_sys0_info(plc_type):
     prefix = plc_type[:4]
 
-    if prefix in {'5/02', '1761'}:
+    if prefix in {'5/02', '1761'}:  # MLX1100, SLC 5/02
         return {
             'file_position': 93,
             'row_size': 8,
             'file_type': b'\x00',
             'size_element': b'\x23'
         }
-    elif prefix in {'1763', '1762', '1764'}:  # MLX 1100, 1200, 1500
+    elif prefix in {'1763', '1762', '1766', '1764'}:  # MLX 1100, 1200, 1400, 1500
         return {
-            'file_position': 103,
+            'file_position': 233,
             'row_size': 10,
             'file_type': b'\x02',
             'size_element': b'\x28',
             'size_const': 19968   # no idea why, but this seems like a const added to the size? wtf?
         }
-    elif prefix in {'1763', }:  # MLX 1400
-        return {
-            'file_position': 103,
-            'row_size': 10,
-            'file_type': b'\x03',
-            'size_element': b'\x2b',
-            'size_const': 19968
-        }
-    else:
+    else:  # SLC 5/04, 5/05
         return {
             'file_position': 79,
             'row_size': 10,

--- a/pycomm3/slc.py
+++ b/pycomm3/slc.py
@@ -322,7 +322,8 @@ def _parse_file0(sys0_info, data):
 def _get_sys0_info(plc_type):
     prefix = plc_type[:4]
 
-    if prefix in {'5/02', '1761'}:  # MLX1100, SLC 5/02
+    if prefix in {'1761', }:  # MLX1000, SLC 5/02
+        # FIXME: Not sure if these are correct, never tested
         return {
             'file_position': 93,
             'row_size': 8,
@@ -330,6 +331,7 @@ def _get_sys0_info(plc_type):
             'size_element': b'\x23'
         }
     elif prefix in {'1763', '1762', '1766', '1764'}:  # MLX 1100, 1200, 1400, 1500
+        # FIXME: values from 1100 and 1400, not tested on 1200/1500
         return {
             'file_position': 233,
             'row_size': 10,
@@ -337,7 +339,7 @@ def _get_sys0_info(plc_type):
             'size_element': b'\x28',
             'size_const': 19968   # no idea why, but this seems like a const added to the size? wtf?
         }
-    else:  # SLC 5/04, 5/05
+    else:  # SLC 5/05
         return {
             'file_position': 79,
             'row_size': 10,

--- a/pycomm3/slc.py
+++ b/pycomm3/slc.py
@@ -298,7 +298,7 @@ def _parse_file0(sys0_info, data):
     num_data_files = data[52]
     num_lad_files = data[46]
     print(f'data files: {num_data_files}, logic files: {num_lad_files}')
-    # file_pos, row_size = _get_file_position_row_size_for_plc_type(plc_type)
+
     file_pos = sys0_info['file_position']
     row_size = sys0_info['row_size']
 
@@ -335,7 +335,7 @@ def _get_sys0_info(plc_type):
             'size_element': b'\x23',
             'size_len': b'\x04',
         }
-    elif prefix in {'1763', '1762', '1766', '1764'}:  # MLX 1100, 1200, 1400, 1500
+    elif prefix in {'1763', '1762', '1764'}:  # MLX 1100, 1200, 1500
         # FIXME: values from 1100 and 1400, not tested on 1200/1500
         return {
             'file_position': 233,
@@ -344,6 +344,15 @@ def _get_sys0_info(plc_type):
             'size_element': b'\x28',
             'size_len': b'\x08',
             'size_const': 19968   # no idea why, but this seems like a const added to the size? wtf?
+        }
+    elif prefix in {'1766', }:  # MLX 1400
+        return {
+            'file_position': 233,
+            'row_size': 10,
+            'file_type': b'\x03',
+            'size_element': b'\x2b',
+            'size_len': b'\x08',
+            'size_const': 19968,  # no idea why, but this seems like a const added to the size? wtf?
         }
     else:  # SLC 5/05
         return {

--- a/pycomm3/slc.py
+++ b/pycomm3/slc.py
@@ -227,7 +227,7 @@ class SLCDriver(CIPDriver):
             b'\x00',  # status code
             Pack.uint(self._sequence),  # transaction identifier
             b'\xa1',  # function code, from RSLinx capture
-            b'\x04',  # size
+            sys0_info['size_len'],  # size
             b'\x00',  # file number
             sys0_info['file_type'],
             sys0_info['size_element'],
@@ -328,7 +328,8 @@ def _get_sys0_info(plc_type):
             'file_position': 93,
             'row_size': 8,
             'file_type': b'\x00',
-            'size_element': b'\x23'
+            'size_element': b'\x23',
+            'size_len': b'\x04',
         }
     elif prefix in {'1763', '1762', '1766', '1764'}:  # MLX 1100, 1200, 1400, 1500
         # FIXME: values from 1100 and 1400, not tested on 1200/1500
@@ -337,6 +338,7 @@ def _get_sys0_info(plc_type):
             'row_size': 10,
             'file_type': b'\x02',
             'size_element': b'\x28',
+            'size_len': b'\x08',
             'size_const': 19968   # no idea why, but this seems like a const added to the size? wtf?
         }
     else:  # SLC 5/05
@@ -344,7 +346,8 @@ def _get_sys0_info(plc_type):
             'file_position': 79,
             'row_size': 10,
             'file_type': b'\x01',
-            'size_element': b'\x23'
+            'size_element': b'\x23',
+            'size_len': b'\x04',
         }
 
 


### PR DESCRIPTION
- added `SLCDriver.get_file_directory` method
  - only SLC support confirmed working, MicroLogix 1100 may be working, other MLX models are not working (need hardware to test against and get correct values)
- added L-file support 