### PR TITLE
tox.ini paths now compatible with Linux & Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,12 @@ setenv =
 
 [testenv:online]
 commands =
-    pytest tests\online
+    pytest tests/online
 
 [testenv:offline]
 commands =
-    pytest tests\offline
+    pytest tests/offline
 
 [testenv:user]
 commands =
-    pytest --ignore tests\online\test_demo_plc.py
+    pytest --ignore tests/online/test_demo_plc.py


### PR DESCRIPTION
Windows by default has a C:\Dir\Path convention while Linux forces a syntax like /dir/path to access a directory.
Because it is only convention in Windows and not required, this edit makes the tox environment work on both Windows and Linux environments.

I tested cloning the repo and running tox before and after this change on both WSL Ubuntu-20.04 and Windows 10 Pro 20H2.
After this change, running tox succeeds on both OS's.
Prior to this change the output on Linux looked like the following:
```
user@DESKTOP-TQ5QU62:/Workspace/pycomm3# tox -e offline
GLOB sdist-make: /Workspace/pycomm3/setup.py
offline inst-nodeps: /Workspace/pycomm3/.tox/.tmp/package/1/pycomm3-0.12.0.zip
offline installed: attrs==20.3.0,iniconfig==1.1.1,packaging==20.8,pluggy==0.13.1,py==1.10.0,pycomm3==0.12.0,pyparsing==2.4.7,pytest==6.2.1,toml==0.10.2
offline run-test-pre: PYTHONHASHSEED='3864003464'
offline run-test: commands[0] | pytest 'tests\offline'
================================================================= test session starts ==================================================================
platform linux -- Python 3.8.1, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
cachedir: .tox/offline/.pytest_cache
rootdir: /Workspace/pycomm3
collected 0 items

================================================================ no tests ran in 0.00s =================================================================
ERROR: file or directory not found: tests\offline

ERROR: InvocationError for command /Workspace/pycomm3/.tox/offline/bin/pytest 'tests\offline' (exited with code 4)
_______________________________________________________________________ summary ________________________________________________________________________
ERROR:   offline: commands failed
```