### PR TITLE
Increase the test coverage of pycomm3

### DIFF
--- a/pycomm3/cip_base.py
+++ b/pycomm3/cip_base.py
@@ -99,8 +99,8 @@ class CIPDriver:
         """
 
         self._sequence_number = 1
-        self._sock = None
-        self._session = 0
+        self._sock = kwargs.get('socket', None)
+        self._session = kwargs.get('session', None)
         self._connection_opened = False
         self._target_cid = None
         self._target_is_connected = False

--- a/tests/offline/packets/test_requests.py
+++ b/tests/offline/packets/test_requests.py
@@ -1,0 +1,129 @@
+
+from pycomm3.cip_base import CIPDriver
+from unittest import mock
+
+import pytest
+from pycomm3.const import DataType
+from pycomm3.exceptions import CommError, PycommError, RequestError
+from pycomm3.packets.requests import (
+    RequestPacket,
+    ReadTagFragmentedServiceRequestPacket,
+    WriteTagFragmentedServiceRequestPacket,
+    MultiServiceRequestPacket,
+    request_path,
+    _make_write_data_tag,
+    _make_write_data_bit
+)
+from pycomm3.packets.responses import (
+    ReadTagServiceResponsePacket
+)
+from pycomm3.packets import RequestTypes
+
+CONNECT_PATH = '192.168.1.100/1'
+
+def test_send_raises_commerror_with_no_plc():
+    packet = RequestPacket(None)
+    with mock.patch.object(RequestPacket, '_build_request'):
+        with pytest.raises(CommError):
+            packet.send()
+
+
+packet_classes = RequestPacket.__subclasses__()
+@pytest.mark.parametrize('packet_cls', packet_classes)
+def test_send_returns_appropriate_response_type(packet_cls):
+    driver = CIPDriver(CONNECT_PATH, sequence=1)
+    packet = packet_cls(driver)
+    with mock.patch.object(RequestPacket, '_build_request'), \
+         mock.patch.object(RequestPacket, '_send'), \
+         mock.patch.object(RequestPacket, '_receive'):
+        response = packet.send()
+        assert isinstance(response, packet._response_class)
+
+packet_classes = RequestPacket.__subclasses__()
+@pytest.mark.parametrize('packet_cls', packet_classes)
+def test_send_calls__send_and__receive(packet_cls):
+    driver = CIPDriver(CONNECT_PATH)
+    packet = packet_cls(driver)
+    with mock.patch.object(RequestPacket, '_build_request'), \
+         mock.patch.object(RequestPacket, '_send') as mock_send, \
+         mock.patch.object(packet_cls, '_receive') as mock_receive:
+        packet.send()
+        assert mock_send.called
+        assert mock_receive.called
+
+def test_ReadTagFragmentedServiceRequestPacket_returns_expected_response_if_error():
+    driver = CIPDriver(CONNECT_PATH)
+    packet = ReadTagFragmentedServiceRequestPacket(driver)
+    packet.error = "Some Error"
+
+    expected_response = ReadTagServiceResponsePacket()
+    expected_response._error = packet.error
+    result = packet.send()
+    assert str(result) == str(expected_response)
+
+def test_default_WriteTagFragmentedServiceRequestPacket_attributes():
+    driver = CIPDriver(CONNECT_PATH)
+    packet = WriteTagFragmentedServiceRequestPacket(driver)
+    assert packet.tag is None
+    assert packet.value is None
+    assert packet.elements is None
+    assert packet.tag_info is None
+    assert packet.request_path is None
+    assert packet.data_type is None
+    assert packet.segment_size is None
+    assert packet.request_id is None
+    assert packet._packed_type is None
+
+def test_default_WriteTagFragmentedServiceRequestPacket_add_exception_sets_error():
+    driver = CIPDriver(CONNECT_PATH)
+    packet = WriteTagFragmentedServiceRequestPacket(driver)
+    packet.add(1, 1, 1, 1, 1, 1)
+    assert packet.error is not None
+
+def test_MultiServiceRequestPacket_add_read_none_request_path_raises_requesterror():
+    driver = CIPDriver(CONNECT_PATH)
+    packet = MultiServiceRequestPacket(driver)
+    with pytest.raises(RequestError):
+        packet.add_read(1, None, 1, 1, 1)
+
+def test_MultiServiceRequestPacket_add_write_none_request_path_raises_requesterror():
+    driver = CIPDriver(CONNECT_PATH)
+    packet = MultiServiceRequestPacket(driver)
+    with pytest.raises(RequestError):
+        packet.add_write(1, None, 1, 1, 1, 1)
+
+def test__make_write_data_tag_raises_requesterror_if_value_not_bytes():
+    with pytest.raises(RequestError):
+        _make_write_data_tag({
+            'tag_type': 'struct',
+            'data_type': None
+        }, None, None, None)
+
+def test__make_write_data_tag_raises_requesterror_if_type_not_struct_and_unknown_data_type():
+    with pytest.raises(RequestError):
+        _make_write_data_tag({
+            'tag_type': 'not a struct',
+            'data_type': 'Not a real data type'
+        }, None, None, None)
+
+def test__make_write_data_tag_returns_bytestring_and_data_type():
+    DATA_TYPE = 'bool'
+    result_bytes, result_dt = _make_write_data_tag({
+        'tag_type': 'not a struct',
+        'data_type': DATA_TYPE
+    }, b'', 1, b'')
+    assert type(result_bytes) == bytes
+    assert result_dt == DATA_TYPE
+
+def test__make_write_data_bit_raises_requesterror_if_mask_size_none():
+    with pytest.raises(RequestError):
+        _make_write_data_bit({
+            'data_type': 'totally invalid datatype'
+        }, 'useless value', 'useless request path')
+
+def test__make_write_data_bit_returns_bytes_if_valid_data_type():
+    result = _make_write_data_bit({
+        'data_type': 'bool'
+    }, (1,  1), b'useless request path')
+
+    assert type(result) == bytes

--- a/tests/offline/packets/test_responses.py
+++ b/tests/offline/packets/test_responses.py
@@ -1,0 +1,34 @@
+"""Response Class and function tests.
+
+It is borderline impossible to cover the responses with tests due to
+extremely high cyclomatic complexity in the methods and functions here.
+
+https://www.sonarsource.com/docs/CognitiveComplexity.pdf
+https://en.wikipedia.org/wiki/Cyclomatic_complexity#Definition
+"""
+from pycomm3.packets.responses import get_extended_status, parse_read_reply_struct
+
+
+def test_unknown_status_size_if_not_branch():
+    TEST_MESSAGE = b'\xFF\xFF'
+    EXPECTED_RESULT = 'Extended Status Size Unknown'
+    assert EXPECTED_RESULT == get_extended_status(TEST_MESSAGE, 0)
+
+def test_no_ext_status_on_lookup_error():
+    EXPECTED_RESULT = 'No Extended Status'
+    assert EXPECTED_RESULT == get_extended_status(b'\x00\x00', 0)
+
+def test_parse_read_reply_struct_with_no_attributes_returns_empty_dict():
+    result = parse_read_reply_struct([0], {
+        'internal_tags': {
+            'parsed_tag_name': {
+                'data_type': 'BOOL',
+                'offset': 0,
+                'tag_type': 'atomic'
+            }
+        },
+        'attributes': []
+    })
+    assert result == {}
+
+    

--- a/tests/offline/test_bytes_.py
+++ b/tests/offline/test_bytes_.py
@@ -1,0 +1,34 @@
+"""Tests for bytes_ functionality.
+
+Almost all of these tests are based on executing the function and using
+the results as the expected value. These are works-as-I-found-it tests,
+not exhibits-expected-behavior-tests.
+"""
+import pytest
+from pycomm3.bytes_ import (
+    print_bytes_msg,
+    _encode_pccc_ascii,
+    _encode_pccc_string
+)
+
+
+def test_print_bytes_msg_returns_expected_output_for_msg():
+    """Existing behavior test for print_bytes_message.
+    
+    This test just validates that the behavior as-is in the code at the
+    time the test was added.
+    """
+    TEST_MESSAGE = b'This is a message'
+    EXPECTED_RESPONSE = '\n(0000) 54 68 69 73 20 69 73 20 61 20 \n(0010) 6d 65 73 73 61 67 65 '
+    assert EXPECTED_RESPONSE == print_bytes_msg(TEST_MESSAGE)
+
+@pytest.mark.parametrize(
+    ['trial_input', 'expected_response'],
+    [('A', b' A'), ('AB', b'BA')]
+)
+def test__encode_pccc_ascii_returns_expected_output_for_string(trial_input, expected_response):
+    assert expected_response == _encode_pccc_ascii(trial_input)
+
+def test__encode_pccc_ascii_raises_valueerror_on_strlen_gt_two():
+    with pytest.raises(ValueError):
+        _encode_pccc_ascii("ABC")

--- a/tests/offline/test_cip_base.py
+++ b/tests/offline/test_cip_base.py
@@ -1,0 +1,268 @@
+"""Tests for the clx.py file.
+
+There are quite a few methods in the CIPDriver which are difficult to
+read or test due to both code clarity and complexity issues. As well as
+there being no way to control the execution of many of the private
+methods through the public API. This has lead to testing of quite a few
+private API methods to achieve an acceptable test coverage.
+"""
+from logging import exception
+from pycomm3.const import SUCCESS
+from pycomm3.packets.responses import RegisterSessionResponsePacket, ResponsePacket, GenericConnectedResponsePacket
+from pycomm3.packets.requests import GenericConnectedRequestPacket, GenericUnconnectedRequestPacket, RegisterSessionRequestPacket, RequestPacket, UnRegisterSessionRequestPacket
+import socket
+from unittest import mock
+
+import pytest
+from pycomm3.cip_base import CIPDriver
+from pycomm3.exceptions import CommError, DataError, PycommError
+from pycomm3.socket_ import Socket
+from pycomm3.tag import Tag
+
+CONNECT_PATH = '192.168.1.100/1'
+DEFAULT_PORT = CIPDriver(CONNECT_PATH,
+    init_info = False,
+    init_tags = False
+)._cfg['port']
+
+def test_cip_get_module_info_raises_data_error_if_response_falsy():
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_generic_message:
+        mock_generic_message.return_value = False
+        with pytest.raises(DataError):
+            driver = CIPDriver(CONNECT_PATH)
+            driver.get_module_info(1)
+
+        assert mock_generic_message.called
+
+def test_get_module_info_returns_expected_identity_dict():
+    EXPECTED_DICT = {
+        'vendor': 'Rockwell Automation/Allen-Bradley', # uint 1 for Rockwell Automation/Allen-Bradley
+        'product_type': 'Residual Gas Analyzer', # uint 0x1E for 'Residual Gas Analyzer'
+        'product_code': 1, # uint
+        'version_major': 1, # int
+        'version_minor': 1, # int
+        'revision': '1.1', # int, int
+        'serial': '00000001', # udint
+        'device_type': 'This is a test',
+        'status': '0000000100000001', # uint
+        'state': 'Major Unrecoverable Fault', # uint 5 Major Unrecoverable Fault
+    }
+    RESPONSE_BYTES = b"\x01\x00\x1E\x00\x01\x00\x01\x01\x01\x01\x01\x00\x00\x00" + \
+        len(EXPECTED_DICT['device_type']).to_bytes(1, 'little') + \
+        bytes(EXPECTED_DICT['device_type'], 'ascii') + int(5).to_bytes(4, 'little')
+    RESPONSE_TAG = Tag("Dummy_tag", RESPONSE_BYTES, type=None, error=None)
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_generic_message:
+        mock_generic_message.return_value = RESPONSE_TAG
+        driver = CIPDriver(CONNECT_PATH)
+        actual_response = driver.get_module_info(1)
+        assert actual_response == EXPECTED_DICT
+
+import itertools
+viable_methods = ['_forward_close', '_un_register_session']
+viable_exceptions = Exception.__subclasses__() + PycommError.__subclasses__()
+param_values = list(itertools.product(viable_methods, viable_exceptions))
+@pytest.mark.parametrize(['mock_method', 'exception'], param_values)
+def test_close_raises_commerror_on_any_exception(mock_method, exception):
+    """Raise a CommError if any CIPDriver methods raise exception.
+    
+    There are two CIPDriver methods called within close:
+        CIPDriver._forward_close()
+        CIPDriver._un_register_session()
+
+    If those internal methods change, this test will break. I think
+    that's acceptable and any changes to this method should make the
+    author very aware that they have changed this method.
+    """
+    with mock.patch.object(CIPDriver, mock_method) as mock_method:
+        mock_method.side_effect = exception
+        with pytest.raises(CommError):
+            driver = CIPDriver(CONNECT_PATH)
+            driver.close()
+
+def test_close_raises_no_error_on_sucessful_run():
+    with mock.patch.object(UnRegisterSessionRequestPacket, 'send') as mock_send, \
+         mock.patch.object(Socket, 'close') as mock_close:
+        mock_send.return_value = True
+        mock_close.return_value = None
+
+        try:
+            driver = CIPDriver(CONNECT_PATH, **{'session': 0, 'socket': Socket()})
+            driver.close()
+        except PycommError:
+            pytest.fail('Unexpected exception')
+
+def test_close_raises_commerror_on_socket_close_exception():
+    with mock.patch.object(Socket, 'close') as mock_close:
+        mock_close.side_effect = Exception
+        with pytest.raises(CommError):
+            driver = CIPDriver(CONNECT_PATH, **{'session': 0, 'socket': Socket()})
+            driver.close()
+
+def test_close_calls_socket_close_if_socket():
+    with mock.patch.object(Socket, 'close') as mock_close:
+        try:
+            driver = CIPDriver(CONNECT_PATH, **{'session': 0, 'socket': Socket()})
+            driver.close()
+        except Exception:
+            pass
+        assert mock_close.called
+
+def test_open_raises_commerror_on_connect_fail():
+    with mock.patch.object(Socket, 'connect') as mock_connect:
+        mock_connect.side_effect = Exception
+        driver = CIPDriver(CONNECT_PATH)
+        with pytest.raises(CommError):
+            driver.open()
+
+def test_open_returns_false_if_register_session_falsy():
+    with mock.patch.object(Socket, 'connect'), \
+         mock.patch.object(CIPDriver, '_register_session') as mock_register:
+        mock_register.return_value = None
+        driver = CIPDriver(CONNECT_PATH)
+        assert not driver.open()
+
+def test_open_returns_true_if_register_session_truthy():
+    with mock.patch.object(Socket, 'connect'), \
+         mock.patch.object(CIPDriver, '_register_session') as mock_register:
+        mock_register.return_value = 1
+        driver = CIPDriver(CONNECT_PATH)
+        assert driver.open()
+
+def test_generic_message_builds_req_with_no_route_path():
+    EXPECTED_CALL_ARGS = {
+        'service': 1,
+        'class_code': 1,
+        'instance': 1,
+        'attribute': 1,
+        'request_data': b'\x00',
+        'data_format': [('blah', 1)],
+    }
+    RESPONSE_PACKET = GenericConnectedResponsePacket(
+        data_format=EXPECTED_CALL_ARGS['data_format']
+    )
+
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(GenericConnectedRequestPacket, 'build') as mock_build, \
+         mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'):
+        mock_send.return_value = RESPONSE_PACKET  # Fake response
+        driver = CIPDriver(CONNECT_PATH, **{'session': 1, 'socket': Socket()})
+        result = driver.generic_message(
+            service=EXPECTED_CALL_ARGS['service'],
+            class_code=EXPECTED_CALL_ARGS['class_code'],
+            instance=EXPECTED_CALL_ARGS['instance'],
+            attribute=EXPECTED_CALL_ARGS['attribute'],
+            request_data=EXPECTED_CALL_ARGS['request_data'],
+            data_format=EXPECTED_CALL_ARGS['data_format']
+        )
+        mock_build.assert_called_once_with(**EXPECTED_CALL_ARGS)
+
+def test_generic_message_returns_tag():
+    RESPONSE_PACKET = GenericConnectedResponsePacket(data_format=[('blah', 1)])
+
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(GenericConnectedRequestPacket, 'build') as mock_build, \
+         mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'):
+        mock_send.return_value = RESPONSE_PACKET  # Fake response
+        driver = CIPDriver(CONNECT_PATH, **{'session': 1, 'socket': Socket()})
+        result = driver.generic_message(
+            service=1,
+            class_code=1,
+            instance=1
+        )
+        assert isinstance(result, Tag)
+
+def test_generic_message_builds_req_with_route_path_bytes():
+    EXPECTED_CALL_ARGS = {
+        'service': 1,
+        'class_code': 1,
+        'instance': 1,
+        'attribute': 1,
+        'request_data': b'\x00',
+        'data_format': [('blah', 1)],
+        'route_path': b'\x00',
+        'unconnected_send': False
+    }
+    RESPONSE_PACKET = GenericConnectedResponsePacket(
+        data_format=EXPECTED_CALL_ARGS['data_format']
+    )
+
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(GenericUnconnectedRequestPacket, 'build') as mock_build, \
+         mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'):
+        mock_send.return_value = RESPONSE_PACKET  # Fake response
+        driver = CIPDriver(CONNECT_PATH, **{'session': 1, 'socket': Socket()})
+        driver.generic_message(
+            service=EXPECTED_CALL_ARGS['service'],
+            class_code=EXPECTED_CALL_ARGS['class_code'],
+            instance=EXPECTED_CALL_ARGS['instance'],
+            attribute=EXPECTED_CALL_ARGS['attribute'],
+            request_data=EXPECTED_CALL_ARGS['request_data'],
+            data_format=EXPECTED_CALL_ARGS['data_format'],
+            route_path=EXPECTED_CALL_ARGS['route_path'],
+            unconnected_send=EXPECTED_CALL_ARGS['unconnected_send'],
+            connected=False  # Send us down the route_path code path.
+        )
+        mock_build.assert_called_once_with(**EXPECTED_CALL_ARGS)
+
+def test__forward_close_returns_false_if_no_response():
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_message:
+        mock_message.return_value = Tag('Falsy_Tag', None, None, None)
+        driver = CIPDriver(CONNECT_PATH, **{'session': 1})
+        assert not driver._forward_close()
+
+def test__forward_close_returns_true_if_response():
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_message:
+        mock_message.return_value = Tag('Truthy_Tag', 'Some Response', None, None)
+        driver = CIPDriver(CONNECT_PATH, **{'session': 1})
+        assert driver._forward_close()
+
+def test__forward_close_raises_commerror_if_session_zero():
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_message:
+        mock_message.return_value = Tag('Falsy_Tag', None, None, None)
+        driver = CIPDriver(CONNECT_PATH, **{'session': 0})
+        with pytest.raises(CommError):
+            driver._forward_close()
+
+@pytest.mark.parametrize('conf_session', range(1, 100))
+def test__register_session_returns_configured_session(conf_session):
+    driver = CIPDriver(CONNECT_PATH, **{'session': conf_session})
+    with mock.patch.object(RequestPacket, 'send'):
+        assert conf_session == driver._register_session()
+
+def test__register_session_returns_none_if_no_response():
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(RequestPacket, 'send') as mock_send:
+        mock_send.return_value = False
+        assert driver._register_session() is None
+
+@pytest.mark.parametrize('conf_session', range(1, 100))
+def test__register_session_returns_session_from_response(conf_session):
+    RESPONSE_PACKET = RegisterSessionResponsePacket()
+    RESPONSE_PACKET.session = conf_session
+    RESPONSE_PACKET.command = "Bogus Command"
+    RESPONSE_PACKET.command_status = SUCCESS
+
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(RequestPacket, 'send') as mock_send:
+        mock_send.return_value = RESPONSE_PACKET
+        assert conf_session == driver._register_session()
+
+
+def test__forward_open_returns_true_if_already_connected():
+    driver = CIPDriver(CONNECT_PATH)
+    driver._target_is_connected = True
+    assert driver._forward_open()
+
+def test__forward_open_returns_false_if_falsy_response():
+    driver = CIPDriver(CONNECT_PATH)
+    with mock.patch.object(CIPDriver, 'generic_message') as mock_message:
+        mock_message.return_value = Tag('Falsy_Tag', None, None, None)
+        assert not driver._forward_open()
+
+def test__forward_open_raises_commerror_if_session_is_zero():
+    driver = CIPDriver(CONNECT_PATH, session=0)
+    with pytest.raises(CommError):
+        driver._forward_open()

--- a/tests/offline/test_cip_base.py
+++ b/tests/offline/test_cip_base.py
@@ -20,10 +20,6 @@ from pycomm3.socket_ import Socket
 from pycomm3.tag import Tag
 
 CONNECT_PATH = '192.168.1.100/1'
-DEFAULT_PORT = CIPDriver(CONNECT_PATH,
-    init_info = False,
-    init_tags = False
-)._cfg['port']
 
 def test_cip_get_module_info_raises_data_error_if_response_falsy():
     with mock.patch.object(CIPDriver, 'generic_message') as mock_generic_message:

--- a/tests/offline/test_clx.py
+++ b/tests/offline/test_clx.py
@@ -1,0 +1,200 @@
+"""Tests for the clx.py file.
+
+The Logix Driver is beholden to the CIPDriver interface. Only tests
+which bind it to that interface should be allowed here. Tests binding
+to another interface such as Socket are an anti-pattern.
+
+There are quite a few methods in the LogixDriver which are difficult to
+read or test due to both code clarity issues and it being inconvenient.
+
+Also the vast majority of methods are private, I think that private 
+methods should not be tested directly, but rather, their effects on
+public methods should be tested.
+
+pytest --cov=pycomm3 --cov-branch tests/offline/
+----------- coverage: platform linux, python 3.8.1-final-0 -----------
+Name                           Stmts   Miss Branch BrPart  Cover
+----------------------------------------------------------------
+pycomm3/clx.py                   798    718    346      0     7%
+
+We're currently at 7% test coverage, I would like to increase that to >=50%
+and then continue to do so for the rest of the modules.
+"""
+from pycomm3.packets.responses import ResponsePacket
+from pycomm3.const import MICRO800_PREFIX, SUCCESS
+from pycomm3.packets.requests import RequestPacket
+import socket
+from unittest import mock
+
+import pytest
+from pycomm3.cip_base import CIPDriver
+from pycomm3.clx import LogixDriver, tag_request_path, writable_value, _tag_return_size
+from pycomm3.exceptions import CommError, PycommError, RequestError
+from pycomm3.socket_ import Socket
+from pycomm3.tag import Tag
+
+CONNECT_PATH = '192.168.1.100/1'
+
+def test_logix_driver_init_with_default_params_attempts_to_connect():
+    """Show LogixDriver attempts connection with default params."""
+    with mock.patch.object(LogixDriver, 'open') as mock_clx_open:
+        try:
+            ld = LogixDriver(CONNECT_PATH)
+        except Exception:
+            pass
+    assert mock_clx_open.called
+
+def test_logix_init_w_false_init_tags_and_info_does_not_attempt_open():
+    """Show LogixDriver avoids connection with false init params."""
+    with mock.patch.object(LogixDriver, 'open') as mock_clx_open:
+        try:
+            ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+        except Exception:
+            pass
+    assert not mock_clx_open.called
+
+def test_logix_init_w_init_info_set_calls_plc_info_and_name():
+    with mock.patch.object(LogixDriver, 'open'), \
+         mock.patch.object(LogixDriver, 'get_plc_info') as mock_info, \
+         mock.patch.object(LogixDriver, 'get_plc_name') as mock_name, \
+         mock.patch.object(CIPDriver, '_list_identity') as mock_identity:
+        mock_identity.return_value = {'product_name': "not micro800"}
+        LogixDriver(CONNECT_PATH, init_info = True, init_tags = False)
+    assert mock_info.called
+    assert mock_identity.called
+    assert mock_name.called
+
+def test_logix_init_micro800_avoids_plc_name():
+    with mock.patch.object(LogixDriver, 'open'), \
+         mock.patch.object(LogixDriver, 'get_plc_info'), \
+         mock.patch.object(LogixDriver, 'get_plc_name') as mock_name, \
+         mock.patch.object(CIPDriver, '_list_identity') as mock_identity:
+        mock_identity.return_value = {'product_name': MICRO800_PREFIX}
+        LogixDriver(CONNECT_PATH, init_info = True, init_tags = False)
+    assert not mock_name.called
+
+def test_logix_init_calls_get_tag_list_if_init_tags():
+    with mock.patch.object(LogixDriver, 'open'), \
+         mock.patch.object(LogixDriver, 'get_tag_list') as mock_tag:
+        LogixDriver(CONNECT_PATH, init_info = False, init_tags = True)
+    assert mock_tag.called
+
+def test_logix_context_manager_calls_open_and_close():
+    with mock.patch.object(LogixDriver, 'open') as mock_open, \
+         mock.patch.object(LogixDriver, 'close') as mock_close:
+        with LogixDriver(CONNECT_PATH, init_info = False, init_tags = False):
+            pass
+
+        assert mock_open.called
+        assert mock_close.called
+
+def test__exit__returns_false_on_commerror():
+    ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+    assert False == ld.__exit__(None, None, None)  # Exit with no exception
+
+def test__exit__returns_true_on_no_error_and_no_exc_type():
+    with mock.patch.object(LogixDriver, 'close'):
+        ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+        assert True == ld.__exit__(None, None, None)
+
+def test__exit__returns_false_on_no_error_and_exc_type():
+    with mock.patch.object(LogixDriver, 'close'):
+        ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+        assert False == ld.__exit__('Some Exc Type', None, None)
+
+def test__repr___ret_str():
+    ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+    assert str == type(ld.__repr__())
+
+
+
+def test_default_logix_tags_are_empty_dict():
+    """Show that LogixDriver tags are an empty dict on init."""
+    ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+    assert ld.tags == dict()
+
+def test_logix_connected_false_on_init_with_false_init_params():
+    ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+    assert ld.connected == False
+
+def test_logix_writeable_value_raises_requesterror_on_value_mismatch():
+    with pytest.raises(RequestError):
+        writable_value({
+            'value': 'Hello',
+            'elements': 1,
+            'tag_info': {
+                'data_type': 'WORD'
+            }
+        })
+
+def test_clx_writeable_value_returns_bytes_if_bytes():
+    TEST_PARSED_TAG = {'value': b'some bytes'}
+    assert TEST_PARSED_TAG['value'] == writable_value(TEST_PARSED_TAG)
+
+
+def test_clx_get_plc_time_sends_packet():
+    with mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch('pycomm3.cip_base.with_forward_open'):
+        ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+        ld.get_plc_time()
+        assert mock_send.called
+
+def test_clx_set_plc_time_sends_packet():
+    with mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch('pycomm3.cip_base.with_forward_open'):
+        ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+        ld.set_plc_time()
+        assert mock_send.called
+
+EXAMPLE_TAG = {
+    'tag_info': {
+        'tag_type': 'atomic',
+        'data_type': 'bool'
+    },
+    'elements': 15
+}
+def test__tag_return_size_returns_int():
+    assert type(_tag_return_size(EXAMPLE_TAG)) == int
+
+def test__tag_return_size_returns_correct_size_for_bool():
+    assert _tag_return_size(EXAMPLE_TAG) == 15
+
+@pytest.mark.skip(reason="""tag parsing is extremely complex, and it's \
+nearly impossible to test this without also reverse-engineering it""")
+def test__get_tag_list_returns_expected_user_tags():
+    EXPECTED_USER_TAGS = [{
+        'tag_type': 'struct', # bit 15 is a 1
+        'instance_id': 1,
+        'tag_name': b"\x00\x01",
+        'symbol_type': "",
+        'symbol_address': "",
+        'symbol_object_address': "",
+        'software_control': "",
+        'external_access': "",
+        'dimensions': ["", "", ""]
+    }]
+
+    TEST_RESPONSE = ResponsePacket()
+    # 0 -> 4 are the 'instance', dint
+    # 4 -> 6 is the 'tag_length', uint, used internally
+    # 8 -> 'tag_length' is 'tag_name'
+    # 8+tag_length -> 10+tag_length is 'symbol_type' uint
+    # 10+tag_length -> 14+tag_length is 'symbol_address' udint
+    # 14+tag_length -> 18+tag_length is 'symbol_object_address' udint
+    # 18+tag_length -> 22+tag_length is 'software_control' udint
+    # 'dim1', 'dim2' and 'dim3' are the next 12 bytes, udint
+    TEST_RESPONSE.data = \
+        b"\x00\x00\x00\x01" + \
+        b"\x00\x01" + \
+        b"\x00\x01" + \
+        b"\x00\x00\x00\x00\x00\x10"
+    TEST_RESPONSE.command = "Something"
+    TEST_RESPONSE.command_status = SUCCESS
+
+    ld = LogixDriver(CONNECT_PATH, init_info = False, init_tags = False)
+    with mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'), \
+         mock.patch.object(LogixDriver, '_parse_instance_attribute_list'):
+        mock_send.return_value = TEST_RESPONSE
+        actual_tags = ld.get_tag_list()
+    assert EXPECTED_USER_TAGS == actual_tags

--- a/tests/offline/test_slc.py
+++ b/tests/offline/test_slc.py
@@ -1,0 +1,79 @@
+"""Tests for the SLCDriver
+
+The methods and functions in the slc.py file are extraordinarily
+difficult to test.
+"""
+
+from pycomm3.const import SLC_REPLY_START, SUCCESS
+from pycomm3.packets.responses import ResponsePacket, SendUnitDataResponsePacket
+from pycomm3.cip_base import CIPDriver
+from unittest import mock
+
+import pytest
+from pycomm3.exceptions import DataError, RequestError
+from pycomm3.packets.requests import RequestPacket
+from pycomm3.slc import SLCDriver, _parse_read_reply
+from pycomm3.tag import Tag
+
+CONNECT_PATH = '192.168.1.100/1'
+
+def test_slc_list_identity_raises_notimplementederror():
+    driver = SLCDriver(CONNECT_PATH)
+
+    with pytest.raises(NotImplementedError):
+        driver.list_identity(CONNECT_PATH)
+
+def test_slc__read_tag_raises_requesterror_for_none():
+    driver = SLCDriver(CONNECT_PATH)
+
+    with mock.patch('pycomm3.slc.parse_tag', return_value=None):
+        with pytest.raises(RequestError):
+            driver._read_tag(None)
+
+def test_slc__read_tag_returns_tag():
+    TEST_PARSED_TAG = {
+        'file_type': 'N',
+        'file_number': '1',
+        'element_number': '1',
+        'pos_number': '1',
+        'address_field': 2,
+        'element_count': 1,
+        'tag': 'Dummy Parsed Tag'
+    }
+    RESPONSE_PACKET = ResponsePacket(b'\x00')
+    driver = SLCDriver(CONNECT_PATH)
+
+    with mock.patch('pycomm3.slc.parse_tag', return_value=TEST_PARSED_TAG), \
+         mock.patch.object(RequestPacket, 'send') as mock_send:
+        mock_send.return_value = RESPONSE_PACKET
+        assert type(driver._read_tag("Anything at all")) == Tag
+
+def test_slc_get_processor_type_returns_none_if_falsy_response():
+    driver = SLCDriver(CONNECT_PATH)
+    RESPONSE_PACKET = SendUnitDataResponsePacket(b'\x00')
+
+    with mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'):
+        mock_send.return_value = RESPONSE_PACKET
+        assert driver.get_processor_type() is None
+
+def test_slc_get_processor_type_returns_none_if_parsing_exception():
+    driver = SLCDriver(CONNECT_PATH)
+    EXPECTED_TYPE = None
+    
+
+    with mock.patch.object(RequestPacket, 'send') as mock_send, \
+         mock.patch.object(CIPDriver, '_forward_open'), \
+         mock.patch.object(ResponsePacket, '_parse_reply'):
+        RESPONSE_PACKET = SendUnitDataResponsePacket(b'\x00')
+        RESPONSE_PACKET.command = "Something"
+        RESPONSE_PACKET.command_status = SUCCESS
+        
+        mock_send.return_value = RESPONSE_PACKET
+        assert EXPECTED_TYPE == driver.get_processor_type()
+
+def test__parse_read_reply_raises_dataerror_if_exception():
+    driver = SLCDriver(CONNECT_PATH)
+
+    with pytest.raises(DataError):
+        _parse_read_reply('bad', 'data')

--- a/tests/offline/test_socket_.py
+++ b/tests/offline/test_socket_.py
@@ -39,12 +39,10 @@ def test_socket_connect_raises_commerror_on_timeout():
     with mock.patch.object(socket.socket, 'connect') as mock_socket_connect:
         mock_socket_connect.side_effect = socket.timeout
         my_sock = Socket()
-        try:
+        with pytest.raises(CommError):
             my_sock.connect('123.456.789.101', 12345)
-        except PycommError:
-            pass
+
         mock_socket_connect.assert_called_once()
-        assert pytest.raises(CommError)
 
 def test_socket_send_raises_commerror_on_no_bytes_sent():
     TEST_MSG = b"Meaningless Data"
@@ -52,11 +50,8 @@ def test_socket_send_raises_commerror_on_no_bytes_sent():
     with mock.patch.object(socket.socket, 'send') as mock_socket_send:
         mock_socket_send.return_value = 0    
         my_sock = Socket()
-        try:
+        with pytest.raises(CommError):
             my_sock.send(msg=TEST_MSG)
-        except PycommError:
-            pass
-        assert pytest.raises(CommError)
 
 def test_socket_send_returns_length_of_bytes_sent():
     BYTES_TO_SEND = b"Baah baah black sheep"
@@ -89,13 +84,8 @@ def test_socket_send_raises_commerror_on_socketerror():
         mock_socket_send.side_effect = socket.error
 
         my_sock = Socket()
-        try:
+        with pytest.raises(CommError):
             my_sock.send(TEST_MESSAGE)
-        except PycommError:
-            pass
-
-        assert pytest.raises(CommError)
-
 
 # Prefixing with the data_len value expected in a message. This
 # seems like an implementation detail that should live in cip_base
@@ -130,12 +120,8 @@ def test_socket_receive_raises_commerror_opn_socketerror():
         mock_socket_recv.side_effect = socket.error
 
         my_sock = Socket()
-        try:
+        with pytest.raises(CommError):
             my_sock.receive()
-        except PycommError:
-            pass
-
-        assert pytest.raises(CommError)
 
 def test_socket_close_closes_socket():
     with mock.patch.object(socket.socket, 'close') as mock_socket_close:

--- a/tests/offline/test_socket_.py
+++ b/tests/offline/test_socket_.py
@@ -1,0 +1,144 @@
+"""Tests for socket_.py.
+
+This wrapper around Python sockets is in the critical path of all
+functionality of this library. As such great care should be taken to
+understand and test it.
+
+The Socket class as it currently stands has no dependency injection
+capabilities, and as such the tests will need to make use of mocking in
+order to support the Python socket underneath.
+
+These tests currently bind the code fairly tightly to Python's socket
+object, but in this instance I think that's okay as I don't forsee this
+changing any time soon, and if it did I would rather that be obvious by
+breaking these tests.
+
+The only remaining untested code in Socket is the while loop in receive
+"""
+import socket
+from unittest import mock
+
+import pycomm3
+import pytest
+from pycomm3.exceptions import CommError, PycommError
+from pycomm3.socket_ import Socket
+
+
+def test_socket_init_creates_socket():
+    with mock.patch('socket.socket') as mock_socket:
+        my_sock = Socket()
+        assert my_sock
+        mock_socket.assert_called_once()
+
+def test_socket_connect_raises_commerror_on_timeout():
+    """Test the Socket.connect method.
+
+    This test covers both the calling of Python socket's connect and
+    the pycomm exception being raised.
+    """
+    with mock.patch.object(socket.socket, 'connect') as mock_socket_connect:
+        mock_socket_connect.side_effect = socket.timeout
+        my_sock = Socket()
+        try:
+            my_sock.connect('123.456.789.101', 12345)
+        except PycommError:
+            pass
+        mock_socket_connect.assert_called_once()
+        assert pytest.raises(CommError)
+
+def test_socket_send_raises_commerror_on_no_bytes_sent():
+    TEST_MSG = b"Meaningless Data"
+
+    with mock.patch.object(socket.socket, 'send') as mock_socket_send:
+        mock_socket_send.return_value = 0    
+        my_sock = Socket()
+        try:
+            my_sock.send(msg=TEST_MSG)
+        except PycommError:
+            pass
+        assert pytest.raises(CommError)
+
+def test_socket_send_returns_length_of_bytes_sent():
+    BYTES_TO_SEND = b"Baah baah black sheep"
+
+    with mock.patch.object(socket.socket, 'send') as mock_socket_send:
+        mock_socket_send.return_value = len(BYTES_TO_SEND)
+
+        my_sock = Socket()
+        sent_bytes = my_sock.send(BYTES_TO_SEND)
+
+        mock_socket_send.assert_called_once_with(BYTES_TO_SEND)
+        assert sent_bytes == len(BYTES_TO_SEND)
+
+def test_socket_send_sets_timeout():
+    """Pass along our timeout arg to our socket."""
+    TIMEOUT_VALUE = 1
+    SOCKET_SEND_RESPONSE = 20  # A nonzero number will prevent an exception.
+    with mock.patch.object(socket.socket, 'settimeout') as mock_socket_settimeout, \
+         mock.patch.object(socket.socket, 'send') as mock_socket_send:
+        mock_socket_send.return_value = SOCKET_SEND_RESPONSE
+
+        my_sock = Socket()
+        my_sock.send(b"Some Message", timeout=TIMEOUT_VALUE)
+
+        mock_socket_settimeout.assert_called_with(TIMEOUT_VALUE)
+
+def test_socket_send_raises_commerror_on_socketerror():
+    TEST_MESSAGE = b"Useless Bytes"
+    with mock.patch.object(socket.socket, 'send') as mock_socket_send:
+        mock_socket_send.side_effect = socket.error
+
+        my_sock = Socket()
+        try:
+            my_sock.send(TEST_MESSAGE)
+        except PycommError:
+            pass
+
+        assert pytest.raises(CommError)
+
+
+# Prefixing with the data_len value expected in a message. This
+# seems like an implementation detail that should live in cip_base
+# rather than directly in the Socket wrapper.
+NULL_HEADER_W_DATA_LEN = b'\x00\x00\x00\x01'.ljust(pycomm3.const.HEADER_SIZE, b'\x00') # 256
+RECVD_BYTES = b"These are the bytes we will recv"
+FULL_RECV_MSG = (NULL_HEADER_W_DATA_LEN + RECVD_BYTES).ljust(256+pycomm3.const.HEADER_SIZE, b'\x00')
+
+def test_socket_receive_returns_received_bytes():
+    with mock.patch.object(socket.socket, 'recv') as mock_socket_recv:
+        mock_socket_recv.return_value = FULL_RECV_MSG
+
+        my_sock = Socket()
+        response = my_sock.receive()
+
+        mock_socket_recv.assert_called_once()
+        assert RECVD_BYTES in response
+
+def test_socket_receive_sets_timeout():
+    TIMEOUT_VALUE = 1
+    with mock.patch.object(socket.socket, 'settimeout') as mock_socket_settimeout, \
+         mock.patch.object(socket.socket, 'recv') as mock_socket_recv:
+        mock_socket_recv.return_value = FULL_RECV_MSG
+
+        my_sock = Socket()
+        my_sock.receive(timeout=TIMEOUT_VALUE)
+
+        mock_socket_settimeout.assert_called_with(TIMEOUT_VALUE)
+
+def test_socket_receive_raises_commerror_opn_socketerror():
+    with mock.patch.object(socket.socket, 'recv') as mock_socket_recv:
+        mock_socket_recv.side_effect = socket.error
+
+        my_sock = Socket()
+        try:
+            my_sock.receive()
+        except PycommError:
+            pass
+
+        assert pytest.raises(CommError)
+
+def test_socket_close_closes_socket():
+    with mock.patch.object(socket.socket, 'close') as mock_socket_close:
+        my_sock = Socket()
+        my_sock.close()
+        mock_socket_close.assert_called_once()

--- a/tests/offline/test_tag.py
+++ b/tests/offline/test_tag.py
@@ -8,10 +8,13 @@ def test_tag_truthiness():
     assert not Tag('tag', None, 'DINT', 'Error')
     assert not Tag('tag', 100, 'DINT', 'Error')
 
-
 def test_tag_repr():
     _tag_repr = "Tag(tag='tag_name', value='string value', type='STRING', error=None)"
     assert _tag_repr == repr(Tag('tag_name', 'string value', 'STRING'))
 
     _tag = Tag('tag', 100, 'DINT')
     assert eval(repr(_tag)) == _tag
+
+def test_tag_falsy_when_no_value_or_error():
+    t = Tag('Dummy_Tag', None, None, None)
+    assert not t

--- a/tests/offline/test_util.py
+++ b/tests/offline/test_util.py
@@ -1,0 +1,19 @@
+from pycomm3.util import strip_array, get_array_index
+
+TEST_TAG = "This is a tag"
+
+def test_strip_array_removes_data_past_left_bracket():
+    TEST_ARRAY = "[123]"
+    assert TEST_TAG == strip_array(TEST_TAG + TEST_ARRAY)
+
+def test_strip_array_with_no_array_returns_tag():
+    assert TEST_TAG == strip_array(TEST_TAG)
+
+def test_get_array_index_returns_0_idx_with_no_array():
+    EXPECTED = (TEST_TAG, 0)
+    assert EXPECTED == get_array_index(TEST_TAG)
+
+def test_get_array_index_returns_index_value():
+    TEST_ARRAY = "[123]"
+    EXPECTED = (TEST_TAG, 123)
+    assert EXPECTED == get_array_index(TEST_TAG + TEST_ARRAY)

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,12 @@ setenv =
 
 [testenv:online]
 commands =
-    pytest tests\online
+    pytest tests/online
 
 [testenv:offline]
 commands =
-    pytest tests\offline
+    pytest tests/offline
 
 [testenv:user]
 commands =
-    pytest --ignore tests\online\test_demo_plc.py
+    pytest --ignore tests/online/test_demo_plc.py


### PR DESCRIPTION
My goal was  to raise the overall test coverage to >=50% prior to
any refactoring effort. I was able to achieve raising coverage from
24% to 43%.

Achieving this required heavy use of mocks and testing private
methods, this hints at poor design.

<hr>

I used the following process to add tests to the project as-is in
attempt to reach my target level of coverage:

First I used the pytest-cov plugin to get a sense of the current test
coverage. This helps find the areas of code with the least coverage.
i.e. areas most in need of attention

The output is as follows:
```
$ pytest --cov=pycomm3 --cov-branch tests/offline/
Beginning Omitted for Brevity
...
Name                           Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------
pycomm3/__init__.py               11      0      0      0   100%
pycomm3/_version.py                2      0      2      0   100%
pycomm3/bytes_.py                134     44     76     25    56%
pycomm3/cip_base.py              244    164     76      1    31%
pycomm3/clx.py                   798    718    346      0     7%
pycomm3/const.py                 177      2      4      0    99%
pycomm3/exceptions.py              4      0      0      0   100%
pycomm3/map.py                    31     14     14      0    51%
pycomm3/packets/__init__.py       21      0      0      0   100%
pycomm3/packets/requests.py      421    304     84      0    23%
pycomm3/packets/responses.py     358    269    114      0    19%
pycomm3/slc.py                   273    236    102      0    10%
pycomm3/socket_.py                42     30     10      0    23%
pycomm3/tag.py                    13      1      0      0    92%
pycomm3/util.py                   12      8      4      0    25%
----------------------------------------------------------------
TOTAL                           2541   1790    832     26    24%
```

Finding the coverage around 24% I arbitrarily decided a good
target would be around double.

I followed up by using the `git effort` command to show files
by commit count and active days. This command is found in
the `git-extras` package on Ubuntu based systems.

The output is as follows:
```
git effort --above 10

  path                                          commits    active days

  pycomm3/clx.py............................... 121         68
  README.rst................................... 75          42
  pycomm3/__init__.py.......................... 48          41
  pycomm3/packets/requests.py.................. 46          31
  pycomm3/const.py............................. 39          35
  pycomm3/packets/responses.py................. 36          31
  setup.py..................................... 29          21
  pycomm3/bytes_.py............................ 24          19
  pycomm3/slc.py............................... 21          16
  pycomm3/cip_base.py.......................... 19          12
  pycomm3/packets/__init__.py.................. 15          14
  docs/usage.rst............................... 13          10
```

The most frequently changed files are high priority for testing:
- `pycomm3/clx.py`
- `pycomm3/packets/requests.py`
- `pycomm3/packets/responses.py`
- `pycomm3/bytes_.py`
- `pycomm3/slc.py`
- `pycomm3/cip_base.py`

The python files not in this list are exempt for lack of logic.

I perused these files seeking highly utilized code-paths and discovered
that `LogixDriver` and `SLCDriver` both depend on `CIPDriver` making it
of the more critical code-paths, and `CIPDriver` depends on the `Socket`
wrapper, which does the same.

Despite low change frequency I started by adding tests to `Socket`
believing it to be the most critical.
I followed up with`CIPDriver` -> `LogixDriver` -> `SLCDriver`, and
finished with some various low-hanging fruit.

<hr>

The final output of pytest with the pytest-cov plugin enabled is:
```
----------- coverage: platform linux, python 3.8.1-final-0 -----------
Name                           Stmts   Miss Branch BrPart  Cover
----------------------------------------------------------------
pycomm3/__init__.py               12      0      0      0   100%
pycomm3/_version.py                2      0      2      0   100%
pycomm3/bytes_.py                134     19     76     16    79%
pycomm3/cip_base.py              272     60     84     11    76%
pycomm3/clx.py                   798    657    346      6    14%
pycomm3/const.py                 177      1      4      0    99%
pycomm3/exceptions.py              4      0      0      0   100%
pycomm3/map.py                    35      6     14      3    78%
pycomm3/packets/__init__.py       21      0      0      0   100%
pycomm3/packets/requests.py      421    194     84     10    48%
pycomm3/packets/responses.py     367    164    120     18    47%
pycomm3/slc.py                   280    214    104      2    18%
pycomm3/socket_.py                42      1     10      1    96%
pycomm3/tag.py                    13      1      0      0    92%
pycomm3/util.py                   12      0      4      0   100%
----------------------------------------------------------------
TOTAL                           2590   1317    848     67    43%
```

I was able to achieve 43% test coverage before the design of the code
inhibiting testing became too much burden for a weekend project.

Unfortunately achieving this level of coverage required writing tests
against a lot of private interface. That means these tests currently 
are ow-level/bound to the code as-is, The upside to this is that it will
provide a baseline for demonstrating improvements to the code.