### PR TITLE
Slc tag refactor

### DIFF
--- a/pycomm3/slc_driver.py
+++ b/pycomm3/slc_driver.py
@@ -40,6 +40,7 @@ TagValueType = Union[AtomicValueType, List[Union[AtomicValueType, str]]]
 ReadWriteReturnType = Union[Tag, List[Tag]]
 
 
+
 class SLCDriver(CIPDriver):
     """
     An Ethernet/IP Client driver for reading and writing of data files in SLC or MicroLogix PLCs.
@@ -454,7 +455,8 @@ def parse_tag(tag: str) -> Optional[dict]:
                         'element_count': int(element_count) if element_count is not None else 1,
                         'tag': tag_name}
 
-    t = re.search(r"(?P<file_type>[IO])(:)(?P<element_number>\d{1,3})"
+    t = re.search(r"(?P<file_type>[IO])(?P<file_number>\d{1,3})"
+                  r"(:)(?P<element_number>\d{1,3})"
                   r"(.)(?P<position_number>\d{1,3})"
                   r"(/(?P<sub_element>\d{1,2}))?"
                   r"(?P<_elem_cnt_token>{(?P<element_count>\d+)})?",

--- a/pycomm3/slc_driver.py
+++ b/pycomm3/slc_driver.py
@@ -477,11 +477,7 @@ def parse_tag(tag: str) -> Optional[dict]:
                         'address_field': 2,
                         'element_count': int(element_count) if element_count is not None else 1,
                         'tag': tag_name}
-# IO_RE = re.compile(r"(?P<file_type>[IO])(?P<file_number>\d{1,3})?"
-                #   r"(:)(?P<element_number>\d{1,3})"
-                #   r"((\.)(?P<position_number>\d{1,3}))?"
-                #   r"(/(?P<sub_element>\d{1,2}))?"
-                #   r"(?P<_elem_cnt_token>{(?P<element_count>\d+)})?", flags=re.IGNORECASE)
+
     t = IO_RE.search(tag)
     if t:
         _cnt = t.group('_elem_cnt_token')


### PR DESCRIPTION
OK, after talking to an AB expert, I believe this is the correct behavior. IO files include implicit file numbers, but some folks include them explicitly. I've made it to where the I or O is the authority on the actual file number. Additionally, and where all of my actual problems were stemming from is there is a norm of implicit 0 position numbers meaning a tag for an input that can be written as `I1:0.0/0` should also be able to be written as `I:0/0`. 

And sorry to mix things up in a PR but I also moved the RE patterns to the top and pre-compiled them, which in a simple test exhibited a 4x speedup over the inline implementation.

This should probably be tested by others before being merged. If anyone has SLCs or MLs they can test against?