### PR TITLE
logix_driver.py Method _read_build_multi_requests | Correct empty multi_requests for ReadFragmentedRequests

### DIFF
--- a/pycomm3/logix_driver.py
+++ b/pycomm3/logix_driver.py
@@ -993,6 +993,7 @@ class LogixDriver(CIPDriver):
         """
         creates a list of multi-request packets
         """
+        multi_requests = []
         fragmented_requests = []
         read_requests = []  # [ (request, response_size), ...]
         for request_id, tag_data in parsed_tags.items():
@@ -1035,9 +1036,11 @@ class LogixDriver(CIPDriver):
             current_group.append(req)
             current_response_size += resp_size
 
-        multi_requests = [
-            MultiServiceRequestPacket(self._sequence, group) for group in grouped_requests
-        ]
+        #test if the first list is empty 
+        if grouped_requests[0]:
+            multi_requests = [
+                MultiServiceRequestPacket(self._sequence, group) for group in grouped_requests
+            ]
 
         return multi_requests + fragmented_requests
 


### PR DESCRIPTION
Hello,

If there are several fragmented requests and only fragmented requests, the program crashes on reading.

I find out where the issue is.
In the **_read_build_multi_requests** method:
```
# TODO: this should try and combine these into the fewest packets
grouped_requests = [[]]
current_group = grouped_requests[0]
current_response_size = MULTISERVICE_READ_OVERHEAD
for req, resp_size in read_requests:
    if current_response_size + resp_size > self.connection_size:
        current_group = []
        grouped_requests.append(current_group)
        current_response_size = MULTISERVICE_READ_OVERHEAD

    current_group.append(req)
    current_response_size += resp_size

multi_requests = [
    MultiServiceRequestPacket(self._sequence, group) for group in grouped_requests
]

return multi_requests + fragmented_requests
```

This is because **grouped_requests** is added to **multi_requests** even if **read_requests** is empty. This created an **MultiServiceRequestPacket** with no tag and it crashes the program at the reading.

So I add a test to check if **grouped_requests** is empty. This is maybe not the best way to do it. This is more to show you the issue than a pull request.

Thank you.