### PR TITLE
changed documentation to match returned dict

### DIFF
--- a/pycomm3/logix_driver.py
+++ b/pycomm3/logix_driver.py
@@ -262,7 +262,7 @@ class LogixDriver(CIPDriver):
         - *product_code* - code identifying the product type
         - *revision* - dict of {'major': <major rev (int)>, 'minor': <minor rev (int)>}
         - *serial* - hex string of PLC serial number, e.g. ``'FFFFFFFF'``
-        - *device_type* - string value for PLC device type, e.g. ``'1756-L83E/B'``
+        - *product_name* - string value for PLC device type, e.g. ``'1756-L83E/B'``
         - *keyswitch* - string value representing the current keyswitch position, e.g. ``'REMOTE RUN'``
         - *name* - string value of the current PLC program name, e.g. ``'PLCA'``
 


### PR DESCRIPTION
I think I may have found a mismatch between the documentation and the .info() method. I've tested the method on multiple PLCs of a few different versions, all with the same issue. 

The following code:

`with LogixDriver("10.10.10.10") as plc:
    print(plc.info["device_type"])`

gives a KeyError. 

Printing the entire dict shows all the keys listed in the docs except "device_type", however "product_name" shows up with the same info. 

I think the only place this needed to be updated was in the docstring for the info method in logix_driver.py. 

If there's something I'm missing, let me know. I went ahead and submitted a PR in case this was all that needed to be updated. 