### PR TITLE
timeout spelling "socket_timout" corrected

### DIFF
--- a/pycomm3/cip_driver.py
+++ b/pycomm3/cip_driver.py
@@ -180,11 +180,11 @@ class CIPDriver:
     @property
     def socket_timeout(self):
         """Socket open connection timeout, in seconds"""
-        return self._cfg["socket_timout"]
+        return self._cfg["socket_timeout"]
 
     @socket_timeout.setter
     def socket_timeout(self, value):
-        self._cfg["socket_timout"] = value
+        self._cfg["socket_timeout"] = value
 
     @classmethod
     def list_identity(cls, path) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION


timeout spelling "socket_timout" corrected for socket_timeout getter and setter method in cip_driver.py