### PR TITLE
Timezone fix for get_plc_time

### DIFF
--- a/pycomm3/logix_driver.py
+++ b/pycomm3/logix_driver.py
@@ -368,7 +368,8 @@ class LogixDriver(CIPDriver):
         """
         Set the time of the PLC system clock.
 
-        :param microseconds: None to use client PC clock, else timestamp in microseconds to set the PLC clock to
+        :param microseconds: None to use client PC clock, else timestamp in microseconds to set the PLC clock to.
+                             Timestamp is uS since epoch 1970-1-1, 00:00 UTC
         :return: Tag with status of request
         """
         if microseconds is None:


### PR DESCRIPTION
Fix for logix_driver get_plc_time method to use attribute x06 (UTC time) instead of x0B (local time) with added optional time zone parameter "tz" to convert returned time to a specific local time zone. Returns UTC if this param is omitted. 

Clarification for set_plc_time method's microseconds param that it is relative to the UTC epoch (documentation only). The user now knows they are responsible to convert local time to UTC before calling the method if not omitting the param to use their system clock.