### PR TITLE
Fix SLCDriver odd-length string write and decode issues

### DIFF
--- a/pycomm3/cip/pccc.py
+++ b/pycomm3/cip/pccc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2021 Ian Ottoway <ian@ottoway.dev>
 # Copyright (c) 2014 Agostino Ruscito <ruscito@gmail.com>
@@ -22,7 +21,6 @@
 # SOFTWARE.
 #
 
-from itertools import chain
 from io import BytesIO
 
 from .data_types import INT, DINT, REAL, StringDataType, UINT
@@ -33,17 +31,43 @@ from ..map import EnumMap
 class PCCCStringType(StringDataType):
     @classmethod
     def _slc_string_swap(cls, data):
-        pairs = [
-            (x2, x1) for x1, x2 in (data[i : i + 2] for i in range(0, len(data), 2))
-        ]
-        return bytes(chain.from_iterable(pairs))
+        """
+        Swaps bytes within 16-bit words.
+
+        SLC processors store strings as arrays of 16-bit integers.
+        To read/write them correctly as ASCII, the bytes in each word must be swapped.
+        e.g., 'AB' (0x4142) is stored as 0x4241 on the PLC.
+        """
+        # Create a mutable working copy
+        ba = bytearray(data)
+
+        # Defensive check: Ensure even length to prevent swap crashes
+        # (Though _encode now handles this, it protects _decode against malformed packets)
+        if len(ba) % 2:
+            ba.append(0)
+
+        ba[0::2], ba[1::2] = ba[1::2], ba[0::2]
+
+        return bytes(ba)
 
 
 class PCCC_ASCII(PCCCStringType):
+    """
+    SLC ASCII file type (A).
+    Represents exactly 2 characters packed into a single 16-bit integer.
+    """
     @classmethod
     def _encode(cls, value: str, *args, **kwargs) -> bytes:
-        char1, char2 = value[:2]
-        return (char2 or " ").encode(cls.encoding) + (char1 or " ").encode(cls.encoding)
+        # PCCC ASCII is fixed at 2 bytes.
+        # We truncate longer strings and pad shorter ones with spaces.
+        b_value = (value or "").encode(cls.encoding, "ignore")[:2]
+
+        if len(b_value) == 0:
+            b_value = b"  "
+        elif len(b_value) == 1:
+            b_value = b_value + b" "
+
+        return cls._slc_string_swap(b_value)
 
     @classmethod
     def _decode(cls, stream: BytesIO) -> str:
@@ -51,16 +75,33 @@ class PCCC_ASCII(PCCCStringType):
 
 
 class PCCC_STRING(PCCCStringType):
+    """
+    SLC String file type (ST).
+    Structure: [Length (UINT)] + [Data (82 bytes)]
+    """
     @classmethod
     def _encode(cls, value: str) -> bytes:
-        _len = UINT.encode(len(value))
-        _data = cls._slc_string_swap(value.encode(cls.encoding))
-        return _len + _data
+        # Encode first to handle characters dropped by "ignore"
+        data = (value or "").encode(cls.encoding, "ignore")
+        true_len = len(data)
+
+        # Pad with null byte if length is odd so it aligns to 16-bit words.
+        # This padding is NOT included in the length field.
+        if true_len & 1:
+            data += b'\x00'
+
+        # Return unpadded length + swapped padded data
+        return UINT.encode(true_len) + cls._slc_string_swap(data)
 
     @classmethod
     def _decode(cls, stream: BytesIO) -> str:
+        # Read the explicit length, then the fixed 82-byte buffer
         _len = UINT.decode(stream)
-        return cls._slc_string_swap(stream.read(82)).decode(cls.encoding)
+        raw = stream.read(82)
+
+        # Swap bytes to correct order, then slice to the actual length
+        swapped = cls._slc_string_swap(raw)
+        return swapped[:_len].decode(cls.encoding, "ignore")
 
 
 class PCCCDataTypes(EnumMap):

--- a/tests/offline/test_pccc_string.py
+++ b/tests/offline/test_pccc_string.py
@@ -1,0 +1,61 @@
+import pytest
+from pycomm3.cip.pccc import PCCC_STRING, PCCC_ASCII
+
+def test_pccc_string_odd_length_padding():
+    """
+    Verifies that odd-length strings are padded with a null byte in the payload
+    but the length header remains the original (unpadded) length.
+    Fixes Issue #314.
+    """
+    # Case 1: Odd length string "123" (3 bytes)
+    # Expected: Length=3 (0x0300), Data="12" (0x3231) + "3\x00" (0x0033)
+    # Note: SLC swaps bytes, so "12" -> 0x3231, "3\0" -> 0x0033
+
+    target_value = "123"
+    encoded = PCCC_STRING.encode(target_value)
+
+    # Header: UINT length of 3 (unpadded) -> b'\x03\x00'
+    assert encoded[0:2] == b'\x03\x00'
+
+    # Payload: "123" + pad "\x00" -> "123\x00"
+    # Swapped: "12" (0x32 0x31) -> 0x31 0x32 -> b'\x31\x32'
+    # "3\0" (0x33 0x00) -> 0x00 0x33 -> b'\x00\x33'
+    # Result: b'\x32\x31\x00\x33'
+
+    expected_payload = b'\x32\x31\x00\x33'
+    assert encoded[2:6] == expected_payload
+
+
+def test_pccc_string_decode_truncation():
+    """
+    Verifies that decoding respects the length header and strips garbage data.
+    Fixes Issue #230.
+    """
+    # Simulate a packet from PLC: Length=3, Payload="ABC" followed by garbage/nulls
+    # "ABC" -> b'ABC' padded to b'ABC\x00'
+    # Swapped: 'AB' -> 'BA' (0x4241), 'C\x00' -> '\x00C' (0x0043)
+    # Payload: b'\x42\x41\x00\x43'
+    # Garbage: 78 more bytes of 0xFF
+
+    # Construct the raw stream (Length 3 + 4 bytes valid + garbage)
+    stream_data = b'\x03\x00' + b'\x42\x41\x00\x43' + (b'\xFF' * 78)
+
+    decoded = PCCC_STRING.decode(stream_data)
+
+    # Should return exactly "ABC", ignoring the padding null and the garbage
+    assert decoded == "ABC"
+
+
+def test_pccc_ascii_padding():
+    """
+    Verifies that ASCII strings (file type A) are space-padded to 2 bytes.
+    """
+    # Case 1: Single char "A"
+    # Pad to "A " -> b'A '
+    # Swap: b' A'
+    assert PCCC_ASCII.encode("A") == b' A'
+
+    # Case 2: Empty string ""
+    # Pad to "  " -> b'  '
+    # Swap: b'  '
+    assert PCCC_ASCII.encode("") == b'  '


### PR DESCRIPTION
### Description
This PR addresses critical issues in the `SLCDriver` (PCCC) related to string encoding and decoding. Specifically, it resolves crashes when writing odd-length strings and eliminates garbage data when reading strings. It also includes unit tests verifying these fixes.

### Changes
- **Fixes Writes (Encoding):**
  - **`_slc_string_swap`**: Switched to a safer, optimized slice assignment for byte swapping. Added defensive padding to handle odd-length byte streams, preventing `ValueError` crashes.
  - **`PCCC_STRING._encode`**: Now calculates the string length *after* encoding but *before* padding. This ensures the `.LEN` field sent to the PLC is accurate (unpadded length) while the `.DATA` payload is correctly padded to align with the SLC's 16-bit word architecture.
  - **`PCCC_ASCII._encode`**: Added logic to space-pad strings shorter than 2 bytes, ensuring valid writes to ASCII files.

- **Fixes Reads (Decoding):**
  - **`PCCC_STRING._decode`**: Updated to explicitly read the length (`UINT`) header and slice the decoded string data to that length. This fixes the issue where `read()` would return the full 82-byte buffer containing trailing nulls or garbage data.

### Issues Fixed
- Fixes #314 (Crash when writing odd-length strings)
- Fixes #230 (Read returns garbage/extra characters)