### PR TITLE
fix: use _len instead of _length in Array.decode range()

### DIFF
--- a/pycomm3/cip/data_types.py
+++ b/pycomm3/cip/data_types.py
@@ -869,7 +869,7 @@ def Array(
                 else:
                     _len = _length
 
-                _val = [cls.element_type.decode(stream) for _ in range(_length)]
+                _val = [cls.element_type.decode(stream) for _ in range(_len)]
 
                 if issubclass(cls.element_type, BitArrayType):
                     return list(chain.from_iterable(_val))


### PR DESCRIPTION
Fixed the bug described in issue #336.

The decode method for CIP Array types was using _length instead of _len in the range() call, which resulted in the error: TypeError: _DataTypeMeta object cannot be interpreted as an integer when decoding array types like Array(UINT, ActiveLanguage).

**Root cause:** Line 872 used _length (which can be a DataType meta object) instead of _len (the decoded integer value) when iterating over array elements.

**Fix:** Changed range(_length) to range(_len).

Fixes #336